### PR TITLE
Initialize tutorials section

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -6,7 +6,6 @@ const glob = require("glob")
 const path = require("node:path")
 const highlight = require("@11ty/eleventy-plugin-syntaxhighlight")
 const dedent = require("dedent")
-const util = require('node:util')
 
 module.exports = (eleventyConfig) => {
   eleventyConfig.addPlugin(css)
@@ -73,7 +72,6 @@ module.exports = (eleventyConfig) => {
   }
   const menu = (first, ...rest) => [menumap[first] || `<strong>${first}</strong>`, ...rest].join(icon("chevron-right"))
 
-  eleventyConfig.addShortcode("json", util.inspect)
   eleventyConfig.addShortcode("icon", icon)
   eleventyConfig.addShortcode("shortcut", shortcut)
   eleventyConfig.addShortcode("menu", menu)

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -6,6 +6,7 @@ const glob = require("glob")
 const path = require("node:path")
 const highlight = require("@11ty/eleventy-plugin-syntaxhighlight")
 const dedent = require("dedent")
+const util = require('node:util')
 
 module.exports = (eleventyConfig) => {
   eleventyConfig.addPlugin(css)
@@ -31,7 +32,9 @@ module.exports = (eleventyConfig) => {
 
   eleventyConfig.addGlobalData("repository", "https://github.com/WebComponentsGuide/webcomponents.guide")
 
-  for (const group of require("./_data/groups.json")) {
+  const customGroups = require("./_data/groups.json")
+
+  for (const group of customGroups.learn) {
     eleventyConfig.addCollection(group, (api) => {
       return api
         .getFilteredByGlob("learn/**/*.md")
@@ -39,7 +42,13 @@ module.exports = (eleventyConfig) => {
         .sort((a, b) => a.data.order - b.data.order)
     })
   }
-
+    
+  eleventyConfig.addCollection("tutorials", (api) => {
+    return api
+      .getFilteredByGlob("tutorials/*-tutorial/index.md")
+      .sort((a, b) => a.data.order - b.data.order)
+  })
+    
   const icon = (icon) =>
     `<svg width="24" height="24" class="icon icon-${icon}"><use xlink:href="/images/icons.svg#${icon}"></use></svg>`
   const callout = (content, style = "info") => dedent`
@@ -64,6 +73,7 @@ module.exports = (eleventyConfig) => {
   }
   const menu = (first, ...rest) => [menumap[first] || `<strong>${first}</strong>`, ...rest].join(icon("chevron-right"))
 
+  eleventyConfig.addShortcode("json", util.inspect)
   eleventyConfig.addShortcode("icon", icon)
   eleventyConfig.addShortcode("shortcut", shortcut)
   eleventyConfig.addShortcode("menu", menu)

--- a/_data/groups.json
+++ b/_data/groups.json
@@ -1,1 +1,4 @@
-["Getting Started", "JavaScript", "Components"]
+{
+  "learn": ["Getting Started", "JavaScript", "Components"],
+  "toot-embed-tutorial": ["Toot Embed Tutorial", "Getting Started"]
+}

--- a/_includes/learn.html
+++ b/_includes/learn.html
@@ -17,29 +17,12 @@ css: [learn.css]
 
 <section class="content">{{ content }}</section>
 
-{% if collections[group] %}
+
+{% if next %}
 <nav class="pagination" aria-label="Pagination">
-  {% assign previousPost = collections[group] | getPreviousCollectionItem: page %} {% assign nextPost =
-  collections[group] | getNextCollectionItem: page %} {% if previousPost %}
-  <a slot="prev" href="{{ previousPost.url }}">
-    <span>Previous</span>
-    {% icon "arrow-left-circle" %} {{ previousPost.data.title }}
-  </a>
-  {% elsif prevGroup %} {% assign previousPost = collections[prevGroup] | first %}
-  <a slot="prev" href="{{ previousPost.url }}">
-    <span>Previous Section</span>
-    {% icon "arrow-left-circle" %} {{ prevGroup }}
-  </a>
-  {% endif %} {% if nextPost %}
-  <a slot="next" href="{{ nextPost.url }}">
+  <a slot="next" href="{{ next }}">
     <span>Next</span>
-    {{ nextPost.data.title }} {% icon "arrow-right-circle" %}
+    {{ nextTitle }} {% icon "arrow-right-circle" %}
   </a>
-  {% elsif nextGroup %} {% assign nextPost = collections[nextGroup] | first %}
-  <a slot="next" href="{{ nextPost.url }}">
-    <span>Next Section</span>
-    {{ nextGroup }} {% icon "arrow-right-circle" %}
-  </a>
-  {% endif %}
 </nav>
 {% endif %}

--- a/_includes/learn.html
+++ b/_includes/learn.html
@@ -17,12 +17,36 @@ css: [learn.css]
 
 <section class="content">{{ content }}</section>
 
-
 {% if next %}
 <nav class="pagination" aria-label="Pagination">
   <a slot="next" href="{{ next }}">
     <span>Next</span>
     {{ nextTitle }} {% icon "arrow-right-circle" %}
   </a>
+</nav>
+{% else if collections[group] %}
+<nav class="pagination" aria-label="Pagination">
+  {% assign previousPost = collections[group] | getPreviousCollectionItem: page %} {% assign nextPost =
+  collections[group] | getNextCollectionItem: page %} {% if previousPost %}
+  <a slot="prev" href="{{ previousPost.url }}">
+    <span>Previous</span>
+    {% icon "arrow-left-circle" %} {{ previousPost.data.title }}
+  </a>
+  {% elsif prevGroup %} {% assign previousPost = collections[prevGroup] | first %}
+  <a slot="prev" href="{{ previousPost.url }}">
+    <span>Previous Section</span>
+    {% icon "arrow-left-circle" %} {{ prevGroup }}
+  </a>
+  {% endif %} {% if nextPost %}
+  <a slot="next" href="{{ nextPost.url }}">
+    <span>Next</span>
+    {{ nextPost.data.title }} {% icon "arrow-right-circle" %}
+  </a>
+  {% elsif nextGroup %} {% assign nextPost = collections[nextGroup] | first %}
+  <a slot="next" href="{{ nextPost.url }}">
+    <span>Next Section</span>
+    {{ nextGroup }} {% icon "arrow-right-circle" %}
+  </a>
+  {% endif %}
 </nav>
 {% endif %}

--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -1,7 +1,7 @@
 <nav class="sidebar-nav" popover id="sidebar-nav">
   <div slot="global-nav">{% include 'global-navigation.html' %} {% include 'global-search.html' %}</div>
   <nav>
-    {%- for g in groups %}
+    {%- for g in groups.learn %}
     <details {% if group == g %}open{% endif %}>
       <summary>{% icon "arrow-down-right" %} {{g}}</summary>
       <ol>

--- a/learn/learn.11tydata.js
+++ b/learn/learn.11tydata.js
@@ -3,12 +3,12 @@ module.exports = {
   tags: ["learn"],
   eleventyComputed: {
     nextGroup(data) {
-      const i = data.groups.indexOf(data.group)
-      return i >= 0 ? data.groups[i + 1] : null
+      const i = data.groups.learn.indexOf(data.group)
+      return i >= 0 ? data.groups.learn[i + 1] : null
     },
     prevGroup(data) {
-      const i = data.groups.indexOf(data.group)
-      return i >= 0 ? data.groups[i - 1] : null
+      const i = data.groups.learn.indexOf(data.group)
+      return i >= 0 ? data.groups.learn[i - 1] : null
     },
   },
 }

--- a/tutorials/index.md
+++ b/tutorials/index.md
@@ -1,6 +1,23 @@
 ---
+order: 1
+group: Getting Started
+title: Introduction
 ---
 
-There doesn't appear to be anything here!
+Welcome to the tutorial section on Web Components! In this section, you will find a range of tutorials that will teach you how to create your own reusable and modular components for the web using Web Components.
 
-{% stub %}
+Web Components are a set of standardized APIs that allow developers to create reusable components that can be used across frameworks and libraries. They enable you to create encapsulated and modular pieces of UI that can be easily shared and reused in your applications.
+
+Our tutorials will guide you through the process of creating your own Web Components from scratch, covering a range of topics including the different APIs available for creating Web Components, how to use them to build efficient and maintainable components, and best practices for working with Web Components.
+
+We hope that these tutorials will provide you with the knowledge and skills you need to create your own Web Components and start building more modular and reusable UI for the web.
+
+{%- for page in collections.tutorials %}
+  {%- unless page.data.draft %}
+  <li>
+    <a href="{{ page.url }}">{{ page.data.title }}</a>
+  </li>
+  {%- endunless %}
+{%- else %}
+  <p>Collection empty</p>
+{%- endfor %}

--- a/tutorials/toot-embed-tutorial/index.md
+++ b/tutorials/toot-embed-tutorial/index.md
@@ -1,0 +1,25 @@
+---
+order: 1
+group: Toot Embed Tutorial
+title: A Mastodon Toot embed Component.
+next: setting-up
+---
+
+{% stub %}
+
+Welcome to this tutorial on building a Mastodon toot embed element using Web Components! In this tutorial, we will walk through the process of creating a custom element that can be used to easily display Mastodon toots on any website or application.
+
+Our Mastodon toot embed element will allow users to share and display toots from the Mastodon social network, and will include features such as the ability to show or hide the user handle and avatar image, as well as the option to customize the appearance of the toot.
+
+Here's a example of a Mastodon toot embed. We'll be making something similar.
+
+<iframe src="https://fosstodon.org/@koddsson/109535622423696807/embed" class="mastodon-embed" style="max-width: 100%; border: 0" width="400" allowfullscreen="allowfullscreen"></iframe><script src="https://fosstodon.org/embed.js" async="async"></script>
+
+We will start by setting up the project files and dependencies, and then move on to defining the Mastodon toot embed element class, extending the HTMLElement class, and registering the element with the browser. We will also cover adding properties and methods to the element, using a shadow DOM for improved styling and separation of concerns, and adding interactivity to the element.
+
+Finally, we will look at integrating the Mastodon toot embed element with a real-world project, including tips for building and using the element in a production environment.
+
+Throughout this tutorial, we will explore the various features and capabilities of Web Components, and how they can be used to build reusable and modular components for the web.
+
+So let's get started!
+

--- a/tutorials/toot-embed-tutorial/setting-up.md
+++ b/tutorials/toot-embed-tutorial/setting-up.md
@@ -1,0 +1,88 @@
+---
+order: 2
+group: Toot Embed Tutorial
+title: Setting Up Your Environment
+---
+
+{% stub %}
+
+Welcome to this tutorial on using Web Components to build a custom element for embedding Mastodon toots! In this tutorial, we will walk through the process of creating a custom element that can be used to display Mastodon toots on any website or application.
+
+The Mastodon toot embed element will allow users to easily share and display toots from the Mastodon social network on their own websites. It will include features such as the ability to show or hide the user handle and avatar image, as well as the option to customize the appearance of the toot.
+
+To get started, we will need to set up the project files and dependencies. This will include creating the files needed for the element and a demo site to showcase the Web Component.
+
+Once the project is set up, we will move on to defining the Mastodon toot embed element class, extending the HTMLElement class, and registering the element with the browser using the customElements.define() method.
+
+If you don't want to do all the manual work you can use [this GitHub template](https://github.com/github/custom-element-boilerplate/) which should have the project set up in the correct way. I'd still reccomend setting the project up manually as you can tweak systems as you set them up.
+
+I hope you're excited to get started! Let's begin by setting up the project files and dependencies.
+
+First, create a new project folder and navigate to it in your terminal. Then, initialize a new npm project by running the following command:
+
+`npm init -y`
+
+This will create a package.json file in your project folder.
+
+Next, create the following file and folder structure:
+
+```
+├── package.json 
+├── index.html 
+├── README.md 
+└── src     
+	└── toot-embed-element.js
+```
+
+In the `src` folder, create a new file called `toot-embed-element.js`. This file will contain the logic and behavior for your Mastodon toot embed element.
+
+To get started, you can use the following template as a starting point for your element class:
+
+```js
+class TootEmbedElement extends HTMLElement {   
+	constructor() {     
+		super();  
+	}    
+	
+	connectedCallback() {     
+		// This method is called when the element is added to the DOM   
+	}    
+	
+	disconnectedCallback() {     
+		// This method is called when the element is removed from the DOM   
+	}    
+	
+	static get observedAttributes() {     
+		// This method returns an array of attribute names to be observed for changes   
+	} 
+	
+	attributeChangedCallback(attrName, oldVal, newVal) {     
+		// This method is called when an observed attribute has been changed   
+	} 
+}  
+customElements.define('toot-embed', TootEmbedElement);
+```
+
+This boilerplate code defines a basic custom element class that extends the HTMLElement class, and includes the `connectedCallback`, `disconnectedCallback`, and `observedAttributes` methods. The `connectedCallback` method is called when the element is added to the DOM, the `disconnectedCallback` method is called when the element is removed from the DOM, and the `observedAttributes` method is called when an observed attribute changes.
+
+To register the element with the browser, we use the `customElements.define()` method, passing in the element name and the element class as arguments.
+
+In your `index.html` file, include a script tag to import your `toot-embed-element.js` file, and a link tag to import any CSS styles that you want to apply to your element. For example:
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<title>&lt;toot-embed&gt; demo</title>
+		<script defer src="/src/toot-embed-element.js"></script>
+	</head>
+	<body>
+		<p>Here's a example toot:<p>
+		<toot-embed src="https://fosstodon.org/@koddsson/109462441325942229"></toot-embed>
+	</body>
+</html>
+```
+
+With these steps, you should now have a project setup with a basic Mastodon toot embed element that can be used to display toots from the Mastodon social network on any website or application.
+
+The Web Component of course doesn't do anything yet. We need to implement the actual functionality and render the contents on the page.

--- a/tutorials/toot-embed-tutorial/toot-embed-tutorial.11tydata.js
+++ b/tutorials/toot-embed-tutorial/toot-embed-tutorial.11tydata.js
@@ -1,0 +1,16 @@
+module.exports = {
+  layout: "learn.html",
+  tags: ["tutorial"],
+  eleventyComputed: {
+    nextTitle(data) {
+      const groups = data.groups["toot-embed-tutorial"]
+      const i = groups.indexOf(data.group)
+      return i >= 0 ? groups[i + 1] : null
+    },
+    prevTitle(data) {
+      const groups = data.groups["toot-embed-tutorial"]
+      const i = groups.indexOf(data.group)
+      return i >= 0 ? groups[i - 1] : null
+    },
+  },
+}

--- a/tutorials/tutorials.json
+++ b/tutorials/tutorials.json
@@ -1,4 +1,4 @@
 {
-  "layout": "tutorials.html",
+  "layout": "learn.html",
   "tags": ["tutorials"]
 }


### PR DESCRIPTION
Here's some changes to the tutorials overview and the start of a `<embed-toot>` component tutorial. It's a bit rough around the edges but I think this is good to merge and then follow up with changes. The pagination and related changes could do with a bit of refactoring but I think that will get smoothed out as we learn how to use 11ty better 😄 