### PR TITLE
Remove vertical for non-pre code elements

### DIFF
--- a/css/global.css
+++ b/css/global.css
@@ -45,6 +45,7 @@
 
 :where(:not(pre) > code) {
   color: var(--text-2);
+  padding: 0 var(--size-2);
 }
 
 html:focus-within {


### PR DESCRIPTION
We import `open-props/normalize.min.css` in `global.css`. It includes a rule to add a background and padding for `:where(:not(pre) > code)` elements. The vertical padding is a problem as it can result in the background of the code element to cover the text in the surrounding lines. To prevent that remove the vertical padding to prevent that.

Fix #224

## Screenshot

This is how it looks after the change

<img width="1006" height="266" alt="image" src="https://github.com/user-attachments/assets/5ae88345-5422-4afe-b8e6-29f8e3bfb255" />

